### PR TITLE
Add Identity & Access guide; update docs

### DIFF
--- a/_data/toc.yml
+++ b/_data/toc.yml
@@ -16,6 +16,8 @@
           url: "docs/general/"
         - title: Shared Responsibility
           url: "docs/general/shared-responsibility"
+        - title: Identity & Access
+          url: "docs/general/identity"
         - title: Security
           url: "docs/general/security/"
         - title: Compliance

--- a/_data/toc.yml
+++ b/_data/toc.yml
@@ -28,6 +28,8 @@
           url: "docs/general/cost-management"
         - title: Account Contacts
           url: "docs/general/contacts"
+        - title: Support
+          url: "docs/general/support"
         - title: Research
           url: "docs/general/research"
         - title: Data Management

--- a/docs/aws/first-steps.md
+++ b/docs/aws/first-steps.md
@@ -61,20 +61,21 @@ role themselves — add yourself as a member if you also want access.
 
 ---
 
-## Step 3 — Set Account Contacts
+## Step 3 — Review Account Contacts
 
-Set **alternate contacts** so billing, operations, and security notifications
-reach your team — not just the person who first requested the account. See
+Your account's **alternate contacts** — the Billing, Operations, and Security
+addresses that receive notifications such as security findings, service health
+events, and billing notices — are **set automatically when your account is
+provisioned**, using the contact information you supplied on your account
+request form. There is nothing you need to set up.
+
+To see what is on file, open the account menu (top right) → **Account** and
+scroll to **Alternate contacts**.
+
+To change a contact, open a [ServiceNow ticket](https://ucsb.service-now.com/it?id=it_sc_cat_item&sys_id=c60e6bf2dbf398900c2e38f0ad961908&sysparm_category=eb1eaff2dbf398900c2e38f0ad9619d5)
+so the Cloud Team can update it. Use a shared functional email address rather
+than a personal one, so contacts survive staff changes. See
 [Account Contacts]({{ "/docs/general/contacts" | relative_url }}) for general best practices.
-
-1. In the AWS Console, open the account menu (top right) → **Account**.
-2. Scroll to **Alternate contacts** and click **Edit**.
-3. Set the **Billing**, **Operations**, and **Security** contacts to your
-   team's functional email addresses, then save.
-
-Use a shared functional email address rather than a personal one, so contacts
-survive staff changes. For details, see
-[AWS docs: Adding, changing, or removing alternate contacts](https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-update-contact-alternate.html).
 
 ---
 

--- a/docs/aws/first-steps.md
+++ b/docs/aws/first-steps.md
@@ -2,7 +2,7 @@
 title: AWS First Steps
 description: What to do after your AWS account is provisioned — sign in, set up billing, deploy your first resource.
 permalink: /docs/aws/first-steps
-last_reviewed: 2026-04-06
+last_reviewed: 2026-05-29
 redirect_from:
   - /docs/firststeps/awsfirststeps
 ---
@@ -61,7 +61,24 @@ role themselves — add yourself as a member if you also want access.
 
 ---
 
-## Step 3 — Review Guardrails
+## Step 3 — Set Account Contacts
+
+Set **alternate contacts** so billing, operations, and security notifications
+reach your team — not just the person who first requested the account. See
+[Account Contacts]({{ "/docs/general/contacts" | relative_url }}) for general best practices.
+
+1. In the AWS Console, open the account menu (top right) → **Account**.
+2. Scroll to **Alternate contacts** and click **Edit**.
+3. Set the **Billing**, **Operations**, and **Security** contacts to your
+   team's functional email addresses, then save.
+
+Use a shared functional email address rather than a personal one, so contacts
+survive staff changes. For details, see
+[AWS docs: Adding, changing, or removing alternate contacts](https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-update-contact-alternate.html).
+
+---
+
+## Step 4 — Review Guardrails
 
 Policy controls (SCPs) are applied at the organization level and cannot be
 modified at the account level. Before building, familiarize yourself with the
@@ -70,7 +87,7 @@ encounter unexpected `Access Denied` errors.
 
 ---
 
-## Step 4 — Configure Networking
+## Step 5 — Configure Networking
 
 If your request included campus network connectivity:
 
@@ -83,7 +100,7 @@ can be deployed via the [Service Catalog]({{ "/docs/aws/service-catalog" | relat
 
 ---
 
-## Step 5 — Deploy Your First Resource
+## Step 6 — Deploy Your First Resource
 
 Use the [Service Catalog]({{ "/docs/aws/service-catalog" | relative_url }}) to deploy
 pre-approved infrastructure templates. This is the fastest way to get
@@ -102,7 +119,7 @@ aws s3 ls --profile my-ucsb-account
 
 ---
 
-## Step 6 — Tag Your Resources
+## Step 7 — Tag Your Resources
 
 All resources must be tagged with the required tags. Missing tags will
 eventually trigger compliance alerts or resource removal.
@@ -111,7 +128,7 @@ See the [Tagging]({{ "/docs/general/tagging" | relative_url }}) page for require
 
 ---
 
-## Step 7 — Create a Budget Alarm
+## Step 8 — Create a Budget Alarm
 
 Set a Budget alarm so that you are alerted before you exceed your budget (see [AWS docs: Create a billing alarm to monitor your estimated charges](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/monitor_estimated_charges_with_cloudwatch.html)):
 

--- a/docs/aws/guardrails.md
+++ b/docs/aws/guardrails.md
@@ -64,13 +64,20 @@ be performed by the organization management account instead.
 
 ## Amazon Bedrock (Generative AI)
 
-**Amazon Bedrock is available in us-east-1, us-west-2, and also us-east-2 and
-us-west-1.**
+**In the two standard regions (us-east-1 and us-west-2), Bedrock works fully —
+both the AWS Console and the API/CLI**, like any other allowed service.
 
-Bedrock works in both standard allowed regions (us-east-1 and us-west-2). An
-additional SCP exception allows Bedrock API calls in **us-east-2** (Ohio) and
-**us-west-1** (N. California) for models that are not available in the standard
-regions. All other services remain blocked in those two regions.
+An additional SCP exception allows **programmatic-only** Bedrock access in two
+otherwise-blocked regions — **us-east-2** (Ohio) and **us-west-1**
+(N. California) — for models that are not offered in the standard regions. In
+these two regions:
+
+* **Only the Bedrock model APIs work** — for example, invoking a model from the
+  AWS SDK or CLI.
+* **The Bedrock console will not work.** It depends on many other actions that
+  remain blocked in us-east-2 and us-west-1, so you must call Bedrock
+  programmatically there.
+* All other AWS services remain blocked in these two regions.
 
 ---
 

--- a/docs/aws/guardrails.md
+++ b/docs/aws/guardrails.md
@@ -2,7 +2,7 @@
 title: AWS Guardrails & SCPs
 description: Service Control Policies and Control Tower controls applied to all Campus Cloud AWS accounts.
 permalink: /docs/aws/guardrails
-last_reviewed: 2026-04-30
+last_reviewed: 2026-05-29
 redirect_from:
   - /docs/guidelines/guardrails/aws
 ---
@@ -13,7 +13,7 @@ UCSB Campus Cloud enforces guardrails — automatic restrictions that keep every
 AWS account aligned with university security policy
 ([UC IS-3](https://security.ucop.edu/policies/institutional-information-and-it-resource-classification.html))
 and the federal
-[NIST 800-171]({{ "/glossary" | relative_url }}) standard for
+[NIST 800-171]({{ "/glossary/" | relative_url }}) standard for
 protecting sensitive research data.
 
 Guardrails are designed to maintain a safe, compliant baseline without getting
@@ -64,12 +64,13 @@ be performed by the organization management account instead.
 
 ## Amazon Bedrock (Generative AI)
 
-**Amazon Bedrock is available in us-east-1, us-west-2, and also us-east-2.**
+**Amazon Bedrock is available in us-east-1, us-west-2, and also us-east-2 and
+us-west-1.**
 
 Bedrock works in both standard allowed regions (us-east-1 and us-west-2). An
-additional SCP exception allows Bedrock API calls in **us-east-2** (Ohio) for
-models that are not available in the standard regions. All other services remain
-blocked in us-east-2.
+additional SCP exception allows Bedrock API calls in **us-east-2** (Ohio) and
+**us-west-1** (N. California) for models that are not available in the standard
+regions. All other services remain blocked in those two regions.
 
 ---
 

--- a/docs/aws/index.md
+++ b/docs/aws/index.md
@@ -74,9 +74,9 @@ When your account is provisioned, the Cloud Team will:
 
 ## Regions
 
-All workloads must run in **us-east-1 or us-west-2** (with a limited exception
-for Amazon Bedrock). See [Guardrails & SCPs]({{ "/docs/aws/guardrails" | relative_url }}) for details
-and exceptions.
+All workloads must run in **us-east-1 or us-west-2** (with a limited,
+programmatic-only Amazon Bedrock exception in two additional regions). See
+[Guardrails & SCPs]({{ "/docs/aws/guardrails" | relative_url }}) for details and exceptions.
 
 ---
 

--- a/docs/aws/networking.md
+++ b/docs/aws/networking.md
@@ -2,7 +2,7 @@
 title: AWS Networking
 description: VPC options, campus connectivity, Transit Gateway, and IP address management for AWS accounts.
 permalink: /docs/aws/networking
-last_reviewed: 2026-04-03
+last_reviewed: 2026-05-29
 redirect_from:
   - /docs/bestpractices/vpn
   - /docs/guidelines/networking
@@ -206,10 +206,10 @@ When your account is provisioned, the Cloud Team creates a VPC using one of two
 product types from the
 [Service Catalog]({{ "/docs/aws/service-catalog" | relative_url }}):
 
-| VPC Type | Campus Network Access | Internet Access | Use When |
+| VPC Type | Subnets | Campus Network Access | Use When |
 |---|---|---|---|
-| Advanced VPC (Campus Connected) | Yes (via Transit Gateway) | Yes (via NAT) | You need to reach on-prem file shares, databases, or LDAP |
-| Simple VPC (Internet Only) | No | Yes (via NAT) | Public-facing apps with no campus dependency |
+| Simple VPC with Campus Connectivity | Yes — multi-AZ; you choose a family (below) | Yes (via Transit Gateway) | Most workloads — running servers, databases, or anything needing network connectivity |
+| Advanced VPC | No — an empty VPC you build out yourself | Yes (Transit Gateway foundation) | You need full control over your network design from scratch |
 
 Specify which type you need in your account request or
 [ServiceNow ticket](https://ucsb.service-now.com/it?id=it_sc_cat_item&sys_id=c60e6bf2dbf398900c2e38f0ad961908&sysparm_category=eb1eaff2dbf398900c2e38f0ad9619d5).
@@ -217,8 +217,8 @@ You can have both types in the same account.
 
 ### VPC Families
 
-When you launch a VPC product, choose a **family** that determines the number
-of subnets, their type, and the total IP address space:
+When you launch the **Simple VPC** product, choose a **family** that determines
+the number of subnets, their type, and the total IP address space:
 
 | Family | Subnets | IPs | Subnet Type | Availability Zones |
 |---|---|---|---|---|

--- a/docs/aws/service-catalog.md
+++ b/docs/aws/service-catalog.md
@@ -2,7 +2,7 @@
 title: AWS Service Catalog
 description: Pre-approved, ready-to-deploy infrastructure products available via the AWS Service Catalog.
 permalink: /docs/aws/service-catalog
-last_reviewed: 2026-04-30
+last_reviewed: 2026-05-29
 redirect_from:
   - /docs/bestpractices/servicecatalog
   - /docs/guidelines/servicecatalog
@@ -42,13 +42,13 @@ For full details, see [Launching a product](https://docs.aws.amazon.com/servicec
 
 | Product | What it creates |
 |---|---|
-| Advanced VPC | A fully configured private network with subnets across two availability zones, optional internet access, campus network connectivity via Transit Gateway (when private subnets are selected), and an S3 endpoint. You choose the size and subnet layout. **Use this for most workloads.** |
+| Advanced VPC | An empty VPC with a large block of campus IP space and the foundation for campus connectivity via Transit Gateway, but **no subnets** — you build the subnet layout yourself. Use this only when you need full control over your network design. |
 | Budget Alert and Action on Threshold (Effectual) | An alternative budget product that applies an IAM policy to your account when a spending threshold is reached, actively restricting further resource creation. Use this when you need a hard spending cap rather than just a notification. Deploy to your home region only. See the [Active Budget Controller docs](https://aws-ia.github.io/cloudformation-effectual-activebudgetcontroller/) for configuration details. |
 | Create IAM Role to UCSB Identity Group | Creates an empty IAM role and a matching UCSB Identity group at the same time. Members of that group (managed at [im.ucsb.edu](https://im.ucsb.edu)) can sign in to AWS and assume the role. You add permissions to the role after creation. Role names are limited to 15 characters. |
 | Fixed Monthly Budget with Notification | A monthly spending limit with email alerts. AWS emails you (and an optional second address) when your *forecasted* spend is on track to exceed the limit — by default the alert fires at 120% of your budget, so you get early warning before you actually go over. |
 | Instance Scheduler | Automatically starts and stops your EC2 and RDS instances on a schedule. Use this to avoid paying for instances that run overnight or on weekends when no one needs them. See the [Instance Scheduler on AWS docs](https://docs.aws.amazon.com/solutions/instance-scheduler-on-aws/) for configuration details. |
 | Local Security Notification | An email alert for guardrail violations. Whenever a resource in your account falls out of compliance with an AWS Config rule (a Campus Cloud guardrail), you get an email. Set this up so your team is notified of compliance issues without having to check the console. |
-| Simple VPC with Campus Connectivity | An empty private network with a block of IP addresses reserved from the campus pool. No subnets or internet access are included — use this only if you need to build your network layout from scratch. |
+| Simple VPC with Campus Connectivity | A fully configured private network with subnets across two availability zones, campus network connectivity via Transit Gateway, an S3 endpoint, and optional internet access. You choose the size. **Use this for most workloads.** |
 
 {% include alert.html type="info" title="Product list may change" content="New products are added as the Cloud Team develops them. Log in to the AWS Console and check Service Catalog → Products for the current complete list." %}
 
@@ -60,10 +60,10 @@ Both VPC products reserve IP space from the campus-wide IP Address Manager (IPAM
 
 | Product | Subnets included | Campus network access | Internet access | Use when |
 |---|---|---|---|---|
-| Advanced VPC | Yes — you choose size and layout (public, private, or both) | Yes, via Transit Gateway (when private subnets are selected) | Yes, via Internet Gateway (when public subnets are selected) | You need to run servers, databases, or anything that requires network connectivity |
-| Simple VPC with Campus Connectivity | No — you create subnets yourself | No — Transit Gateway attachment is not included | No | You need full control over your network design from scratch |
+| Simple VPC with Campus Connectivity | Yes — across two availability zones; you choose the size | Yes, via Transit Gateway | Optional, via Internet Gateway | You need to run servers, databases, or anything that requires network connectivity |
+| Advanced VPC | No — you create subnets yourself | Yes — Transit Gateway foundation provided | You build it yourself | You need full control over your network design from scratch |
 
-For most workloads, use **Advanced VPC**. See [Networking]({{ "/docs/aws/networking" | relative_url }}) for more details.
+For most workloads, use **Simple VPC with Campus Connectivity**. See [Networking]({{ "/docs/aws/networking" | relative_url }}) for more details.
 
 ---
 

--- a/docs/azure/guardrails.md
+++ b/docs/azure/guardrails.md
@@ -2,7 +2,7 @@
 title: Azure Guardrails & Policies
 description: Azure Policy assignments and compliance controls applied to all Campus Cloud Azure subscriptions.
 permalink: /docs/azure/guardrails
-last_reviewed: 2026-04-06
+last_reviewed: 2026-05-29
 redirect_from:
   - /docs/guidelines/guardrails/azure
 ---
@@ -13,7 +13,7 @@ UCSB Campus Cloud enforces guardrails — automatic restrictions that keep every
 Azure subscription aligned with university security policy
 ([UC IS-3](https://security.ucop.edu/policies/institutional-information-and-it-resource-classification.html))
 and the federal
-[NIST 800-171]({{ "/glossary" | relative_url }}) standard for
+[NIST 800-171]({{ "/glossary/" | relative_url }}) standard for
 protecting sensitive research data.
 
 Guardrails are designed to maintain a safe, compliant baseline without getting
@@ -23,13 +23,14 @@ allowed.
 
 ---
 
-## Required Resource Group Tags
+## Required Tags
 
-**All Resource Groups should have the four required tags.**
+**Apply the four required tags to your Resource Groups and to taggable
+resources.**
 
-This is enforced with an **Audit** policy — Resource Groups created without the
-required tags will be flagged as non-compliant in Azure Policy, but creation is
-not blocked.
+This is enforced with an **Audit** policy — both Resource Groups and taggable
+resources created without the required tags are flagged as non-compliant in
+Azure Policy, but creation is not blocked.
 
 | Tag | Allowed Values |
 |---|---|
@@ -40,6 +41,9 @@ not blocked.
 
 See [Tagging]({{ "/docs/general/tagging" | relative_url }}) for definitions of protection and
 availability levels.
+
+A fifth tag, `ucsb:po-number`, is also audited. The Cloud Team sets this on
+your subscription at provisioning — you do not need to manage it.
 
 ---
 

--- a/docs/gcp/first-steps.md
+++ b/docs/gcp/first-steps.md
@@ -2,7 +2,7 @@
 title: GCP First Steps
 description: What to do after your GCP project is provisioned — sign in, verify setup, deploy your first resource.
 permalink: /docs/gcp/first-steps
-last_reviewed: 2026-04-30
+last_reviewed: 2026-05-29
 redirect_from:
   - /docs/firststeps/gcpfirststeps
 ---
@@ -32,7 +32,7 @@ Cloud Team. Follow the steps below to get set up.
 
 ---
 
-## Step 2 — Verify Your IAM Role
+## Step 2 — Verify Your Access
 
 1. Navigate to **IAM & Admin → IAM** in the left menu.
 2. Confirm your `@ucsb.edu` account is listed with the appropriate role:
@@ -45,28 +45,53 @@ If you are not listed or your role is incorrect, contact the Cloud Team.
 
 ### Adding and Removing Users
 
-Project Owners can grant roles under **IAM & Admin → IAM** in the GCP Console.
-See [Grant an IAM role](https://cloud.google.com/iam/docs/grant-role-console)
-for step-by-step instructions. Only `@ucsb.edu` accounts can be added —
-personal Gmail accounts are not permitted.
+Every project comes with **four Google Groups** that carry the project's
+access. Manage access by adding and removing people in these groups — **do not
+grant roles to individuals directly** under IAM & Admin → IAM.
+
+| Group | Access it grants |
+|---|---|
+| `prj-<id>-owners@gcp.cloud.ucsb.edu` | Full project access (Owner), **view billing data**, and use of the campus **Shared VPC** |
+| `prj-<id>-editors@gcp.cloud.ucsb.edu` | Create and manage most resources (Editor) |
+| `prj-<id>-viewers@gcp.cloud.ucsb.edu` | Read-only access (Viewer) |
+| `prj-<id>-billing@gcp.cloud.ucsb.edu` | View billing data and read-only project access |
+
+(`<id>` is your project ID. Find the exact group addresses under
+**IAM & Admin → IAM**, where the groups are listed as members.)
+
+{% include alert.html type="warning" title="Use the groups, not direct grants" content="Billing-data access and Shared VPC access are attached to these groups, not to direct IAM grants. If you add someone straight to project IAM, they will be missing billing visibility and the campus network — add them to the appropriate group instead." %}
+
+**To add or remove members**, go to [groups.google.com](https://groups.google.com)
+and open the group. Project owners are **Managers** of all four groups, so they
+can manage membership for every access level. Only `@ucsb.edu` accounts can be
+added — personal Gmail accounts are not permitted.
+
+See [Identity & Access]({{ "/docs/general/identity" | relative_url }}) for the
+cross-provider picture.
 
 ---
 
-## Step 3 — Set Project Contacts
+## Step 3 — Review Project Contacts
 
-GCP uses **Essential Contacts** to route notifications to your team. The Cloud
-Team has configured org-level contacts; you need to add project-level contacts.
-See [Account Contacts]({{ "/docs/general/contacts" | relative_url }}) for general best practices.
+GCP uses **Essential Contacts** to route operational notifications to your team.
+**These are configured automatically** when your project is created — they point
+at your project's access groups, so there is nothing to set up:
 
-1. Navigate to [Essential Contacts](https://console.cloud.google.com/iam-admin/essentialcontacts)
-   with your project selected.
-2. Click **+ Add contact**.
-3. Enter a functional email address and select:
-   * **Security** — Security Command Center findings
-   * **Technical** — Maintenance and service disruption notices
-   * **Billing** — Budget alerts and billing notifications
-4. Confirm by clicking the verification link emailed to that address.
-5. Repeat for each category that needs a different address.
+| Group | Notifications it receives |
+|---|---|
+| `prj-<id>-owners` | All categories — Billing, Legal, Security, Suspension, Technical, and Technical Incidents |
+| `prj-<id>-billing` | Billing only |
+
+Because contacts are tied to the groups, you change **who** receives these
+notifications by managing group membership — the same way you
+[manage access](#step-2--verify-your-access). There is no need to add or verify
+contacts manually.
+
+If you also want notifications sent to an address that isn't a group member (for
+example, a shared ticketing alias), you can add it under
+[Essential Contacts](https://console.cloud.google.com/iam-admin/essentialcontacts)
+with your project selected. See [Account Contacts]({{ "/docs/general/contacts" | relative_url }})
+for general best practices.
 
 ---
 

--- a/docs/gcp/first-steps.md
+++ b/docs/gcp/first-steps.md
@@ -52,7 +52,7 @@ grant roles to individuals directly** under IAM & Admin → IAM.
 | Group | Access it grants |
 |---|---|
 | `prj-<id>-owners@gcp.cloud.ucsb.edu` | Full project access (Owner), **view billing data**, and use of the campus **Shared VPC** |
-| `prj-<id>-editors@gcp.cloud.ucsb.edu` | Create and manage most resources (Editor) |
+| `prj-<id>-editors@gcp.cloud.ucsb.edu` | Create and manage most resources (Editor), and use of the campus **Shared VPC** |
 | `prj-<id>-viewers@gcp.cloud.ucsb.edu` | Read-only access (Viewer) |
 | `prj-<id>-billing@gcp.cloud.ucsb.edu` | View billing data and read-only project access |
 

--- a/docs/gcp/guardrails.md
+++ b/docs/gcp/guardrails.md
@@ -2,7 +2,7 @@
 title: GCP Guardrails & Org Policies
 description: Organization policy constraints and IAM deny policies applied to all Campus Cloud GCP projects.
 permalink: /docs/gcp/guardrails
-last_reviewed: 2026-04-06
+last_reviewed: 2026-05-29
 ---
 
 # GCP Guardrails
@@ -11,7 +11,7 @@ UCSB Campus Cloud enforces guardrails — automatic restrictions that keep every
 GCP project aligned with university security policy
 ([UC IS-3](https://security.ucop.edu/policies/institutional-information-and-it-resource-classification.html))
 and the federal
-[NIST 800-171]({{ "/glossary" | relative_url }}) standard for
+[NIST 800-171]({{ "/glossary/" | relative_url }}) standard for
 protecting sensitive research data.
 
 Guardrails are designed to maintain a safe, compliant baseline without getting
@@ -58,17 +58,17 @@ allowed.
 
 ---
 
-## IAM Deny Policies (Organization-Wide)
+## IAM Deny Policies
 
 IAM deny policies operate before role bindings are evaluated — they are
-absolute restrictions. The Campus Cloud Landing Zone uses 4 deny policies at the org level:
+absolute restrictions. The following deny policies apply to standard Campus
+Cloud projects (those in the UCSB NIST Baseline folder):
 
 | Policy | What It Blocks | Exceptions |
 |---|---|---|
 | Resource Manager Lockdown | Creating/deleting folders, removing project deletion protection, moving projects between folders, changing billing account assignments | Cloud Team automation, org admins (break-glass) |
 | Networking Lockdown | Creating VPC networks | Cloud Team automation only |
 | Automation Account Protection | Modifying org-level access policies outside of the standard process | Cloud Team automation, org admins (break-glass) |
-| Contact Preservation | Deleting or modifying Essential Contacts | Cloud Team automation, org admins, billing admins |
 
 ---
 

--- a/docs/gcp/index.md
+++ b/docs/gcp/index.md
@@ -2,7 +2,7 @@
 title: GCP Overview
 description: Overview of the UCSB Campus Cloud GCP environment — org hierarchy, folders, projects, regions, and what is pre-configured.
 permalink: /docs/gcp/
-last_reviewed: 2026-03-30
+last_reviewed: 2026-05-29
 ---
 
 # GCP at UCSB
@@ -34,7 +34,7 @@ Policies applied at a higher level are inherited by every project underneath.
 | Folder | Purpose |
 |---|---|
 | UCSB NIST Baseline | Production workloads — funded research, academic, and administrative projects with full org-policy enforcement |
-| Sandbox Unfunded | Self-service exploration — any `@ucsb.edu` user can create a project here, but billing cannot be attached |
+| ↳ Sandbox Unfunded | Nested under NIST Baseline. Self-service exploration — any `@ucsb.edu` user can create a project here, but billing cannot be attached |
 | UCSB Legacy | Pre-existing projects that predate the landing zone |
 
 {% include alert.html type="info" title="Sandbox Unfunded — self-service, no billing" content="Any @ucsb.edu user can create a project in the Sandbox Unfunded folder — including projects created automatically by tools like Apps Script. Billing cannot be attached, so most paid services (Compute Engine, Cloud SQL, GKE) are unavailable. Use this folder for exploring the GCP console, IAM, and free-tier services." %}
@@ -45,13 +45,21 @@ Policies applied at a higher level are inherited by every project underneath.
 
 When your project is provisioned, the Cloud Team will:
 
+* **Create per-project access groups** — Four Google Groups (owners, editors,
+  viewers, billing) that carry project, billing, and Shared VPC access; manage
+  access through these instead of granting roles directly (see
+  [Identity & Access]({{ "/docs/general/identity" | relative_url }}))
 * **Block high-risk operations** — Policies prevent actions like granting
   public access or disabling audit logs
 * **Enable Cloud Audit Logs** — Admin Activity logs are stored securely for 3 years
 * **Enable Security Command Center** — Central dashboard for security findings
-* **Require resource labels** — Enforce your team's tags on resources
+* **Require project tags** — Enforce your team's required tags, set at the
+  project level (see [Tagging]({{ "/docs/general/tagging" | relative_url }}))
 * **Restrict networking** — Only the Cloud Team can create VPC networks; request
   networking resources if your project needs them
+* **Route notifications to your team** — Essential Contacts are configured
+  automatically and point at your project's access groups, so security, billing,
+  and operational notices reach the right people
 * **Set a billing budget alert** — Notifies you when spend approaches your
   specified threshold (funded projects only)
 

--- a/docs/gcp/networking.md
+++ b/docs/gcp/networking.md
@@ -2,7 +2,7 @@
 title: GCP Networking
 description: Networking constraints, current limitations, and how to request network resources for GCP projects.
 permalink: /docs/gcp/networking
-last_reviewed: 2026-05-08
+last_reviewed: 2026-05-29
 ---
 
 # GCP Networking Overview
@@ -157,8 +157,15 @@ and the Cloud Team will evaluate an exception.
 
 ## Public-Facing Services
 
-**Serverless services** like Cloud Run, Cloud Functions, and API Gateway can
-serve public internet traffic by default — no org policy exception is needed.
+**Public access is not allowed by default — even for serverless services.** Org
+policy requires authenticated (IAM-based) access to Cloud Run and Cloud
+Functions (`run.managed.requireInvokerIam`), and granting access to `allUsers`
+is separately blocked. By default these services are reachable only by
+identities you authorize, not the open internet.
+
+If you need a Cloud Run or Cloud Functions service to accept unauthenticated
+public traffic, open a
+[ServiceNow ticket](https://ucsb.service-now.com/it?id=it_sc_cat_item&sys_id=c60e6bf2dbf398900c2e38f0ad961908&sysparm_category=eb1eaff2dbf398900c2e38f0ad9619d5).
 
 For **VM-based workloads** that need a public-facing endpoint (e.g., a web
 application behind a load balancer), open a

--- a/docs/gcp/security.md
+++ b/docs/gcp/security.md
@@ -2,7 +2,7 @@
 title: GCP Security
 description: Security monitoring, audit logging, Security Command Center, and incident response for GCP projects.
 permalink: /docs/gcp/security
-last_reviewed: 2026-03-30
+last_reviewed: 2026-05-29
 ---
 
 # GCP Security
@@ -116,12 +116,18 @@ for details.
 
 ---
 
-## Identity Restrictions
+## Identity & Access
 
 **Only @ucsb.edu accounts can access Campus Cloud GCP projects.**
 
 You cannot grant access to personal Gmail addresses or to "all users" —
 attempts to do so will fail with a policy error.
+
+Grant access through your project's **per-project access groups** (owners,
+editors, viewers, billing) rather than adding people directly under IAM — the
+groups also carry billing-data and Shared VPC access. See
+[GCP First Steps — Adding and Removing Users]({{ "/docs/gcp/first-steps#step-2--verify-your-access" | relative_url }})
+and [Identity & Access]({{ "/docs/general/identity" | relative_url }}).
 
 If an external collaborator needs access, contact the Cloud Team to discuss
 options (e.g., a sponsored UCSB account).

--- a/docs/general/contacts.md
+++ b/docs/general/contacts.md
@@ -2,7 +2,7 @@
 title: Account Contacts
 description: Best practices for setting cloud account contacts across all providers
 permalink: /docs/general/contacts
-last_reviewed: 2026-04-03
+last_reviewed: 2026-05-29
 redirect_from:
   - /docs/bestpractices/contacts
 ---
@@ -52,9 +52,9 @@ your provider:
   alert rules. See the
   [Azure notification settings documentation](https://learn.microsoft.com/en-us/azure/defender-for-cloud/configure-email-notifications)
   for Defender for Cloud email configuration.
-* [GCP First Steps — Set Project Contacts]({{ "/docs/gcp/first-steps#step-3--set-project-contacts" | relative_url }}) —
-  Essential Contacts for Security, Technical, and Billing notification
-  categories. See the
+* [GCP First Steps — Review Project Contacts]({{ "/docs/gcp/first-steps#step-3--review-project-contacts" | relative_url }}) —
+  Essential Contacts are configured automatically and routed to your project's
+  access groups; you change recipients by managing group membership. See the
   [GCP Essential Contacts documentation](https://cloud.google.com/resource-manager/docs/managing-notification-contacts)
   for details on notification categories.
 

--- a/docs/general/contacts.md
+++ b/docs/general/contacts.md
@@ -42,9 +42,10 @@ or an unexpected billing spike in time to respond.
 Each provider has a different way to configure contacts. Follow the guide for
 your provider:
 
-* [AWS First Steps — Set Account Contacts]({{ "/docs/aws/first-steps#step-3--set-account-contacts" | relative_url }}) —
-  Alternate contacts (Security, Operations, Billing) in the AWS Account
-  Settings page. See the
+* [AWS First Steps — Review Account Contacts]({{ "/docs/aws/first-steps#step-3--review-account-contacts" | relative_url }}) —
+  Alternate contacts (Security, Operations, Billing) are configured
+  automatically from the information on your account request form; the Cloud
+  Team updates them on request. See the
   [AWS documentation on alternate contacts](https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-update-contact-alternate.html)
   for details on what each contact type receives.
 * [Azure First Steps — Set Subscription Contacts]({{ "/docs/azure/first-steps#step-4--set-subscription-contacts" | relative_url }}) —

--- a/docs/general/cost-management.md
+++ b/docs/general/cost-management.md
@@ -2,7 +2,7 @@
 title: Costs & Billing
 description: Cloud pricing, UC discounts, and how to manage your cloud spending
 permalink: /docs/general/cost-management
-last_reviewed: 2026-04-30
+last_reviewed: 2026-05-29
 redirect_from:
   - /docs/bestpractices/costmodels
   - /docs/aws/quicksight
@@ -81,7 +81,8 @@ Set up a budget alert in your account so you are notified before your spending
 exceeds expectations. Instructions are in each provider's First Steps guide.
 
 * For AWS, use the **Fixed Monthly Budget with Notification** product in the
-  Service Catalog — see [AWS First Steps]({{ "/docs/aws/first-steps" | relative_url }}).
+  [Service Catalog]({{ "/docs/aws/service-catalog" | relative_url }}), or set a
+  billing alarm — see [AWS First Steps]({{ "/docs/aws/first-steps" | relative_url }}).
 * For Azure, use **Azure Cost Management** — see [Azure First Steps]({{ "/docs/azure/first-steps" | relative_url }}).
 * For GCP, use **Cloud Billing budgets** — see [GCP First Steps]({{ "/docs/gcp/first-steps" | relative_url }}).
 

--- a/docs/general/identity.md
+++ b/docs/general/identity.md
@@ -1,0 +1,67 @@
+---
+title: Identity & Access Management
+description: How to grant and manage access to Campus Cloud accounts — UCSB identity, group-based access, and least privilege across AWS, Azure, and GCP.
+permalink: /docs/general/identity
+last_reviewed: 2026-05-29
+---
+
+# Identity & Access Management
+
+Every Campus Cloud account uses your **UCSB identity** — you sign in with your
+`@ucsb.edu` NetID, and only `@ucsb.edu` accounts can be granted access. There
+are no separate cloud passwords to create or manage.
+
+This page covers the principles that apply everywhere. For step-by-step
+instructions, follow the link to each provider's First Steps page.
+
+---
+
+## Manage Access With Groups, Not One-Off Grants
+
+Wherever the platform provides access **groups**, add and remove people through
+the group rather than granting access to individuals directly. Group-based
+access is easier to audit, survives staff turnover, and — importantly — is often
+the *only* way a person receives the full set of permissions they need. A direct
+grant on a single account or project can silently miss related access such as
+**billing data** or the **campus Shared VPC**.
+
+| Provider | How access is granted | Where you manage it |
+|---|---|---|
+| **AWS** | Four role groups per account (Administrator, PowerUser, ReadOnly, Billing) | [im.ucsb.edu](https://im.ucsb.edu) → Manage Group Tags |
+| **GCP** | Four Google Groups per project (owners, editors, viewers, billing) | [groups.google.com](https://groups.google.com) (project owners are group Managers) |
+| **Azure** | Custom RBAC roles assigned to users | Azure portal → Access control (IAM) |
+
+{% include alert.html type="warning" title="GCP: use the project groups" content="On GCP, billing-data access and Shared VPC access are attached to the per-project groups — not to direct IAM grants. Add people to the project's owners/editors/viewers/billing groups so they get the access they actually need. See GCP First Steps." %}
+
+* **AWS** — see [AWS First Steps — Adding and Removing Users]({{ "/docs/aws/first-steps#step-2--review-your-default-roles" | relative_url }}).
+* **GCP** — see [GCP First Steps — Adding and Removing Users]({{ "/docs/gcp/first-steps#step-2--verify-your-access" | relative_url }}).
+* **Azure** — see [Azure First Steps — Adding and Removing Users]({{ "/docs/azure/first-steps#step-3--review-your-roles" | relative_url }}).
+
+---
+
+## Use the Least Privilege Needed
+
+Assign each person the **minimum role** for their responsibilities, and reserve
+the most powerful roles for setup and access-management tasks. See the
+[Least-Privilege Principle]({{ "/docs/general/security#least-privilege-principle" | relative_url }})
+on the Security page for the recommended role for each provider.
+
+---
+
+## Only @ucsb.edu Accounts
+
+All three providers require a `@ucsb.edu` identity. Personal Gmail or Microsoft
+accounts cannot be granted access, and attempts to share an account publicly are
+blocked by guardrails.
+
+For collaborators outside UCSB, see
+[External Collaborators]({{ "/docs/general/security#external-collaborators" | relative_url }}).
+
+---
+
+## Prefer Functional Emails for Ownership
+
+Where you designate an owner or primary contact, use a shared
+[functional email]({{ "/glossary/" | relative_url }}) (e.g.,
+`mylab-cloud@ucsb.edu`) rather than a personal address, so access and
+notifications survive staff changes.

--- a/docs/general/index.md
+++ b/docs/general/index.md
@@ -2,14 +2,13 @@
 title: General Guidance
 description: Cross-provider guidance for security, identity, tagging, compliance, cost management, and more.
 permalink: /docs/general/
-last_reviewed: 2026-04-30
+last_reviewed: 2026-05-29
 redirect_from:
   - /docs/bestpractices
   - /docs/firststeps
   - /docs/guidelines
   - /docs/guidelines/description
   - /getting-started/training
-  - /docs/general/identity
 ---
 
 # General Guidance
@@ -53,6 +52,7 @@ library (free with UCSB NetID) includes:
 | Topic | Description |
 |---|---|
 | [Shared Responsibility]({{ "/docs/general/shared-responsibility" | relative_url }}) | How responsibilities are divided between the cloud providers, the Campus Cloud Team, and you |
+| [Identity & Access]({{ "/docs/general/identity" | relative_url }}) | Granting access with groups, least privilege, and `@ucsb.edu` identity across all providers |
 | [Security]({{ "/docs/general/security" | relative_url }}) | Data classification, security monitoring, least-privilege, and incident response |
 | [Tagging]({{ "/docs/general/tagging" | relative_url }}) | Required tags, naming conventions, and how tags are enforced |
 | [Compliance]({{ "/docs/general/compliance" | relative_url }}) | UC IS-3, NIST 800-171, and how to request a compliant account |

--- a/docs/general/index.md
+++ b/docs/general/index.md
@@ -57,6 +57,7 @@ library (free with UCSB NetID) includes:
 | [Tagging]({{ "/docs/general/tagging" | relative_url }}) | Required tags, naming conventions, and how tags are enforced |
 | [Compliance]({{ "/docs/general/compliance" | relative_url }}) | UC IS-3, NIST 800-171, and how to request a compliant account |
 | [Cost Management]({{ "/docs/general/cost-management" | relative_url }}) | Budgets, alerts, and strategies for controlling cloud spend |
+| [Support]({{ "/docs/general/support" | relative_url }}) | How to reach the Cloud Team, join the community, attend office hours, and schedule an annual check-in |
 | [Research]({{ "/docs/general/research" | relative_url }}) | Guidance for faculty and researchers using cloud for grants and sponsored work |
 | [Data Management]({{ "/docs/general/data-management" | relative_url }}) | Data classification, storage, and retention considerations |
 | [Migrate a Personal Account]({{ "/docs/general/migrate" | relative_url }}) | How to bring an existing personal cloud account into the Campus Cloud |

--- a/docs/general/research.md
+++ b/docs/general/research.md
@@ -2,7 +2,7 @@
 title: Cloud for Research
 description: Using the UCSB Campus Cloud for research computing
 permalink: /docs/general/research
-last_reviewed: 2026-04-07
+last_reviewed: 2026-05-29
 redirect_from:
   - /docs/bestpractices/research
 ---
@@ -110,6 +110,7 @@ for each provider.
 
 **Can I share data with external collaborators?**
 Yes, with appropriate access controls. For P3/P4 data involving CUI or regulated
-data, consult the Cloud Team before sharing externally. GCP and Azure by default
-only allow `@ucsb.edu` accounts — external collaborators may need a UCSB
-affiliate account or guest access.
+data, consult the Cloud Team before sharing externally. All three providers
+require a `@ucsb.edu` identity for account access, so external collaborators
+may need a sponsored UCSB account — see
+[Security — External Collaborators]({{ "/docs/general/security#external-collaborators" | relative_url }}).

--- a/docs/general/security.md
+++ b/docs/general/security.md
@@ -2,7 +2,7 @@
 title: Security
 description: Security guidance for Campus Cloud accounts — data classification, monitoring, least-privilege, and incident response
 permalink: /docs/general/security/
-last_reviewed: 2026-04-06
+last_reviewed: 2026-05-29
 redirect_from:
   - /docs/general/security
   - /docs/guidelines/security
@@ -27,8 +27,10 @@ Assign the minimum role needed for each person's responsibilities:
   and reserve **Administrator** for IAM changes.
 * **Azure** — Use **Application Owner** rather than **Subscription Owner** for
   most day-to-day work.
-* **GCP** — Use project-level roles (Editor, Viewer) instead of broader roles
-  unless explicitly needed.
+* **GCP** — Add people to the per-project access groups (owners, editors,
+  viewers, billing) rather than granting roles directly, and pick the
+  lowest-privilege group that fits. See
+  [Identity & Access]({{ "/docs/general/identity" | relative_url }}).
 
 ---
 

--- a/docs/general/support.md
+++ b/docs/general/support.md
@@ -1,0 +1,78 @@
+---
+title: Support
+description: How to reach the Campus Cloud Team, join the community, attend office hours, and schedule an annual account check-in.
+permalink: /docs/general/support
+last_reviewed: 2026-05-29
+---
+
+# Support
+
+The Campus Cloud Team is here to help with your AWS account, Azure
+subscription, or GCP project. Whether you have a quick question, need to open a
+request, or want to talk through a project, here is how to reach us and connect
+with the wider campus cloud community.
+
+---
+
+## Contact Us
+
+* **Open a support request** — Create a
+  [ServiceNow ticket](https://ucsb.service-now.com/it?id=it_sc_cat_item&sys_id=c60e6bf2dbf398900c2e38f0ad961908&sysparm_category=eb1eaff2dbf398900c2e38f0ad9619d5)
+  for anything that needs tracking, such as account changes, access requests,
+  or billing questions.
+* **Email us** — Reach the team directly at
+  [info@cloud.ucsb.edu](mailto:info@cloud.ucsb.edu).
+
+---
+
+## Join the Community
+
+Anyone at UCSB who uses AWS, Azure, or GCP is welcome to join the **Cloud Impact
+Hub**, our Google Chat space for community support, questions, and best
+practices. It is the fastest way to get a quick answer from the Cloud Team and
+from other cloud users on campus.
+
+[Join the Cloud Impact Hub Google Chat space](https://chat.google.com/room/AAAAN8CAkZY?cls=4)
+
+---
+
+## Office Hours
+
+We hold open office hours every **Thursday from 10:00–11:00 AM**. Anyone is
+welcome to drop in with questions, ideas, or troubleshooting. No appointment is
+needed.
+
+Join the [Cloud Impact Hub Chat space](https://chat.google.com/room/AAAAN8CAkZY?cls=4)
+for the Zoom link and other details.
+
+---
+
+## Annual Account Check-Ins
+
+Each year we schedule a short check-in with every Campus Cloud account owner —
+one per AWS account, Azure subscription, or GCP project. It is a chance to
+discuss your project needs, raise any challenges, and share feedback on your
+Campus Cloud experience. We also use it to highlight any security, budget, or
+compliance items relevant to your account.
+
+A typical check-in covers:
+
+* **Account contacts** — confirming security, billing, and operations contacts
+  are current.
+* **Cost** — budgets, alerts, and spending trends.
+* **Security & compliance** — relevant findings and any data-protection or
+  compliance needs.
+* **Tagging** — keeping resources organized and tagged consistently.
+* **Feedback** — your experience with Campus Cloud and the Landing Zone service.
+
+You don't have to wait for us to reach out. To schedule a check-in proactively:
+
+1. Pick a time using our
+   [check-in booking link](https://calendar.app.google/wSub7WUC3ReWk2Qr9).
+2. Complete the
+   [pre-screening survey](https://docs.google.com/forms/d/e/1FAIpQLSc9mNbijYP7fwdTDfBmHNKDQtbf1Z67wyzhJw19LBJ9_l6XOA/viewform?usp=header)
+   before your meeting so we can prepare.
+
+If you are no longer the right contact for an account, let us know at
+[info@cloud.ucsb.edu](mailto:info@cloud.ucsb.edu) so we can reach the right
+person.

--- a/docs/general/support.md
+++ b/docs/general/support.md
@@ -70,7 +70,7 @@ You don't have to wait for us to reach out. To schedule a check-in proactively:
 1. Pick a time using our
    [check-in booking link](https://calendar.app.google/wSub7WUC3ReWk2Qr9).
 2. Complete the
-   [pre-screening survey](https://docs.google.com/forms/d/e/1FAIpQLSc9mNbijYP7fwdTDfBmHNKDQtbf1Z67wyzhJw19LBJ9_l6XOA/viewform?usp=header)
+   [pre-screening survey](https://docs.google.com/forms/d/e/1FAIpQLSc9mNbijYP7fwdTDfBmHNKDQtbf1Z67wyzhJw19LBJ9_l6XOA/viewform)
    before your meeting so we can prepare.
 
 If you are no longer the right contact for an account, let us know at

--- a/docs/general/tagging.md
+++ b/docs/general/tagging.md
@@ -2,7 +2,7 @@
 title: Tagging & Labels
 description: Required tags across AWS, Azure, and GCP
 permalink: /docs/general/tagging
-last_reviewed: 2026-03-30
+last_reviewed: 2026-05-29
 redirect_from:
   - /docs/bestpractices/tagging
   - /docs/guidelines/tagging
@@ -65,10 +65,12 @@ organization).
 | Azure | Resource group flagged as non-compliant (Audit policy) |
 | GCP | Audit finding; platform automation skips untagged projects |
 
-For Azure, the required tags on **resource groups** are audited by policy:
-`ucsb:environment`, `ucsb:mission`,
-`ucsb:protection-level`, and `ucsb:availability-level`. Resource groups
-without these tags will be flagged as non-compliant but can still be created.
+For Azure, the four required tags are audited by policy on both **resource
+groups** and **taggable resources**: `ucsb:environment`, `ucsb:mission`,
+`ucsb:protection-level`, and `ucsb:availability-level`. Items without these tags
+are flagged as non-compliant but can still be created. (Azure also audits a
+`ucsb:po-number` tag, which the Cloud Team sets at provisioning — you don't
+manage it.)
 
 ---
 

--- a/pages/docs.md
+++ b/pages/docs.md
@@ -3,7 +3,7 @@ layout: page
 title: Documentation
 description: Full index of all Campus Cloud documentation pages.
 permalink: /docs/
-last_reviewed: 2026-04-06
+last_reviewed: 2026-05-29
 ---
 
 # Documentation
@@ -17,6 +17,7 @@ navigate or jump directly to a section below.
 ## General Guidance (All Providers)
  - [General Guidance Overview]({{ "/docs/general/" | relative_url }})
  - [Shared Responsibility]({{ "/docs/general/shared-responsibility" | relative_url }})
+ - [Identity & Access]({{ "/docs/general/identity" | relative_url }})
  - [Security]({{ "/docs/general/security" | relative_url }})
  - [Compliance]({{ "/docs/general/compliance" | relative_url }})
  - [Tagging]({{ "/docs/general/tagging" | relative_url }})

--- a/pages/docs.md
+++ b/pages/docs.md
@@ -23,6 +23,7 @@ navigate or jump directly to a section below.
  - [Tagging]({{ "/docs/general/tagging" | relative_url }})
  - [Cost Management]({{ "/docs/general/cost-management" | relative_url }})
  - [Account Contacts]({{ "/docs/general/contacts" | relative_url }})
+ - [Support]({{ "/docs/general/support" | relative_url }})
  - [Research in the Cloud]({{ "/docs/general/research" | relative_url }})
  - [Data Management]({{ "/docs/general/data-management" | relative_url }})
  - [Migrate a Personal Account]({{ "/docs/general/migrate" | relative_url }})

--- a/pages/getting-started.md
+++ b/pages/getting-started.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Get a Campus Cloud Account"
 permalink: /getting-started
-last_reviewed: 2026-04-30
+last_reviewed: 2026-05-29
 redirect_from:
   - /getting-started/
   - /getting-started/procurement
@@ -29,7 +29,7 @@ All three providers use the same Gateway procurement process. Creating a Purchas
 
 You will not be able to access your account until all steps are completed and the Campus Cloud Team creates it.
 
-1.  Log in to the [UCSB Gateway Procurement System](https://it.ucsb.edu/administration-business/gateway)
+1.  Log in to the [UCSB Gateway Procurement System](https://gateway.procurement.ucsb.edu). If you do not yet have Gateway access, see [About Gateway and how to request access](https://it.ucsb.edu/administration-business/gateway).
 2.  Complete the Campus Cloud Form.
 
     ![Gateway Procurement System home page showing the Campus Cloud form link]({{ "/assets/img/gatewayhome.png" | relative_url }})

--- a/pages/glossary.md
+++ b/pages/glossary.md
@@ -2,7 +2,7 @@
 title: Glossary
 description: Definitions of terms specific to the UCSB Campus Cloud.
 permalink: /glossary/
-last_reviewed: 2026-04-07
+last_reviewed: 2026-05-29
 ---
 
 # Glossary
@@ -18,7 +18,8 @@ that need a campus-specific definition.
 
 | Term | Definition |
 |---|---|
-| **Allowed Regions** | US regions where you can deploy resources: AWS (us-east-1, us-west-2), Azure (West US 2, West Central US), GCP (us-central1, us-west1). |
+| **Access Groups** | Per-account/project groups used to grant access by role instead of granting it to individuals. AWS uses role groups managed at [im.ucsb.edu](https://im.ucsb.edu); GCP creates four Google Groups (owners, editors, viewers, billing) per project. See [Identity & Access]({{ "/docs/general/identity" | relative_url }}). |
+| **Allowed Regions** | US regions where you can deploy resources: AWS (us-east-1, us-west-2), Azure (West US 2, West Central US, East US 2, Central US), GCP (us-central1, us-west1). |
 | **Availability Level (a1–a4)** | How critical uptime is for your resources. Set via the `availability-level` tag. See [Tagging]({{ "/docs/general/tagging" | relative_url }}). |
 | **Baseline** | The standard security configuration applied to every new account — audit logging, guardrails, budget alerts. |
 | **Campus Cloud Account** | General term for your cloud workspace. AWS calls it an *Account*, Azure a *Subscription*, GCP a *Project*. |


### PR DESCRIPTION
Add a new Identity & Access Management page and wire it into the TOC and docs index; update cross-provider guidance to prefer group-based access, require @ucsb.edu identities, and recommend least-privilege. Update GCP docs to document per-project Google Groups, automatic Essential Contacts, stricter serverless public-access policy, and project-contact behavior. Clarify AWS Service Catalog and VPC product descriptions and renumber steps in AWS First Steps (add account contacts step). Note Azure tag auditing details (including ucsb:po-number). Update Bedrock allowed regions and various internal links; refresh last_reviewed dates across many pages and adjust related references in contacts, cost-management, networking, security, tagging, glossary, and getting-started.