### PR TITLE
Clarify GCP governance metadata in glossary

### DIFF
--- a/pages/glossary.md
+++ b/pages/glossary.md
@@ -2,7 +2,7 @@
 title: Glossary
 description: Definitions of terms specific to the UCSB Campus Cloud.
 permalink: /glossary/
-last_reviewed: 2026-05-29
+last_reviewed: 2026-06-07
 ---
 
 # Glossary
@@ -51,9 +51,8 @@ that need a campus-specific definition.
 | **RFC 1918** | Internet standard defining private IP address ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16). Campus Cloud VPCs and VNets use addresses from these ranges. |
 | **Service Catalog** | Pre-approved infrastructure templates you can deploy yourself (VPCs, budgets, EC2 instances, etc.). Currently available in AWS. |
 | **SLO** | Service Level Objective — a target availability percentage (e.g., 99.9% uptime) for a workload. |
-| **Tags / Labels** | Key-value pairs attached to resources for billing attribution, compliance, and governance. AWS and Azure call them *Tags*; GCP calls them *Labels*. |
+| **Tags / Labels** | Key-value pairs used for billing attribution, compliance, and governance. AWS and Azure use tags. GCP Campus Cloud uses Resource Manager Tags for required governance metadata and project labels for billing attribution. |
 | **UC Enterprise Discount** | UC system-wide pricing agreements with cloud providers (AWS EDP, Azure EA, GCP negotiated rates). Applied automatically to Campus Cloud accounts. |
 | **UC Policy IS-3** | University of California Electronic Information Security Policy. Requires data classification and appropriate protections. |
 | **Wiz** | The cloud security posture management (CSPM) tool used across all Campus Cloud environments for agentless vulnerability and misconfiguration scanning. |
 | **WORM** | Write Once, Read Many — a storage mode that prevents stored data from being deleted or modified. Used for audit logs in GCP (3-year retention). |
-


### PR DESCRIPTION
Constraint: Repository guidance keeps UCSB-specific definitions in the glossary and requires substantive edits to refresh last_reviewed.
Rejected: Keep the broad labels-only wording | the tagging page distinguishes GCP Resource Manager Tags from project labels.
Confidence: high
Scope-risk: narrow
Directive: Keep glossary definitions aligned with provider-specific guidance pages.
Tested: Confirmed the old GCP labels-only wording is removed and the glossary matches docs/general/tagging.md.
Not-tested: Local Jekyll build not run because the repo has no Gemfile.